### PR TITLE
修复拦截fetch请求未返回response导致其他第三方库中fetch无法获取到response

### DIFF
--- a/src/web-report-default.js
+++ b/src/web-report-default.js
@@ -458,7 +458,7 @@ function Performance(option, fn) {
                 }
                 return _fetch.apply(this, arguments)
                     .then((res) => {
-                        if (result.type === 'report-data') return;
+                        if (result.type === 'report-data') return res;
                         try {
                             const url = res.url ? res.url.split('?')[0] : '';
                             res.clone().text().then(data => { if (conf.ajaxMsg[url]) conf.ajaxMsg[url]['decodedBodySize'] = data.length; })

--- a/src/web-report-fetch.js
+++ b/src/web-report-fetch.js
@@ -314,7 +314,7 @@ function Performance(option, fn) {
                 }
                 return _fetch.apply(this, arguments)
                     .then((res) => {
-                        if (result.type === 'report-data') return;
+                        if (result.type === 'report-data') return res;
                         getFetchTime('success')
                         try {
                             const url = res.url ? res.url.split('?')[0] : '';


### PR DESCRIPTION
这里拦截了fetch请求但是在`if (result.type === 'report-data')`判断中没有return res，导致在其他第三方库有有拦截fetch请求的地方服务获取到response。