### PR TITLE
拦截的ajax请求响应成功时没有作url过滤，导致无法发送上报请求

### DIFF
--- a/src/web-report-default.js
+++ b/src/web-report-default.js
@@ -41,7 +41,7 @@ function randomString(len) {
 // web msgs report function
 function Performance(option, fn) {
     try {
-        let filterUrl = ['/api/v1/report/web', 'livereload.js?snipver=1', '/sockjs-node/info'];
+        let filterUrl = ['/api/v1/report/web', 'livereload.js?snipver=1', '/sockjs-node/'];
         let opt = {
             // 上报地址
             domain: 'http://localhost/api',
@@ -169,7 +169,7 @@ function Performance(option, fn) {
                     if (begin) return;
                 }
 
-                let result = { url: arg[1], method: arg[0] || 'GET', type: 'xmlhttprequest' }
+                let result = { url: arg[1].split('?')[0], method: arg[0] || 'GET', type: 'xmlhttprequest' }
                 this.args = result
 
                 clearPerformance()

--- a/src/web-report-default.js
+++ b/src/web-report-default.js
@@ -141,11 +141,13 @@ function Performance(option, fn) {
                 }
             },
             onerror: function (xhr) {
-                getAjaxTime('error')
                 if (xhr.args) {
                     xhr.method = xhr.args.method
                     xhr.responseURL = xhr.args.url
                     xhr.statusText = 'ajax request error'
+                    if (conf.ajaxMsg[xhr.responseURL]) {
+                        getAjaxTime('error')
+                    }
                 }
                 ajaxResponse(xhr)
             },

--- a/src/web-report-default.js
+++ b/src/web-report-default.js
@@ -122,13 +122,17 @@ function Performance(option, fn) {
                     setTimeout(() => {
                         if (conf.goingType === 'load') return;
                         conf.goingType = 'readychange';
-                        try {
-                            const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
-                            if (conf.ajaxMsg[responseURL]) {
-                                conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
-                                getAjaxTime('readychange')
-                            }
-                        } catch (err) { }
+                        const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
+                        if (conf.ajaxMsg[responseURL]) {
+                            try {
+                                if (xhr.xhr.response instanceof Blob) {
+                                    conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.response.size;
+                                } else {
+                                    conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                                }
+                            } catch (err) {}
+                            getAjaxTime('readychange')
+                        }
                         if (xhr.status < 200 || xhr.status > 300) {
                             xhr.method = xhr.args.method
                             ajaxResponse(xhr)
@@ -149,13 +153,17 @@ function Performance(option, fn) {
                 if (xhr.readyState === 4) {
                     if (conf.goingType === 'readychange') return;
                     conf.goingType = 'load';
-                    try {
-                        const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
-                        if (conf.ajaxMsg[responseURL]) {
-                            conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
-                            getAjaxTime('load');
-                        }
-                    } catch (err) { }
+                    const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
+                    if (conf.ajaxMsg[responseURL]) {
+                        try {
+                            if (xhr.xhr.response instanceof Blob) {
+                                conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.response.size;
+                            } else {
+                                conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                            }
+                        } catch (err) {}    
+                        getAjaxTime('load');
+                    }
                     if (xhr.status < 200 || xhr.status > 300) {
                         xhr.method = xhr.args.method
                         ajaxResponse(xhr)

--- a/src/web-report-default.js
+++ b/src/web-report-default.js
@@ -122,10 +122,12 @@ function Performance(option, fn) {
                     setTimeout(() => {
                         if (conf.goingType === 'load') return;
                         conf.goingType = 'readychange';
-                        getAjaxTime('readychange')
                         try {
                             const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
-                            if (conf.ajaxMsg[responseURL]) conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                            if (conf.ajaxMsg[responseURL]) {
+                                conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                                getAjaxTime('readychange')
+                            }
                         } catch (err) { }
                         if (xhr.status < 200 || xhr.status > 300) {
                             xhr.method = xhr.args.method
@@ -147,10 +149,12 @@ function Performance(option, fn) {
                 if (xhr.readyState === 4) {
                     if (conf.goingType === 'readychange') return;
                     conf.goingType = 'load';
-                    getAjaxTime('load');
                     try {
                         const responseURL = xhr.xhr.responseURL ? xhr.xhr.responseURL.split('?')[0] : '';
-                        if (conf.ajaxMsg[responseURL]) conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                        if (conf.ajaxMsg[responseURL]) {
+                            conf.ajaxMsg[responseURL]['decodedBodySize'] = xhr.xhr.responseText.length;
+                            getAjaxTime('load');
+                        }
                     } catch (err) { }
                     if (xhr.status < 200 || xhr.status > 300) {
                         xhr.method = xhr.args.method


### PR DESCRIPTION
当请求的时需要过滤的url，不应该调用getAjaxTime方法，否则会导致ajaxLength，loadNum不对应而无法发送上报请求。